### PR TITLE
Move upload artifact custom action to the reusable workflow

### DIFF
--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -106,7 +106,7 @@ jobs:
         uses: mattermost/actions/plugin-ci/setup@78a7031b0c913d2da6db285945e3ddcec191eead
 
       - name: ci/build
-        uses: mattermost/actions/plugin-ci/build@main
+        uses: mattermost/actions/plugin-ci/build@22d7d0350214a27f24bebba563ea9f6a05aecd6f
 
   delivery:
     # if: ${{ github.ref_name  == 'master' }}

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -62,10 +62,10 @@ jobs:
           cache: true
 
       - name: ci/setup
-        uses: mattermost/actions/plugin-ci/setup@a137067c750390bfc228375dbe745b2aa3a566e8
+        uses: mattermost/actions/plugin-ci/setup@78a7031b0c913d2da6db285945e3ddcec191eead
 
       - name: ci/lint
-        uses: mattermost/actions/plugin-ci/lint@a137067c750390bfc228375dbe745b2aa3a566e8
+        uses: mattermost/actions/plugin-ci/lint@78a7031b0c913d2da6db285945e3ddcec191eead
 
   test:
     runs-on: ubuntu-latest
@@ -82,10 +82,10 @@ jobs:
           cache: true
 
       - name: ci/setup
-        uses: mattermost/actions/plugin-ci/setup@a137067c750390bfc228375dbe745b2aa3a566e8
+        uses: mattermost/actions/plugin-ci/setup@78a7031b0c913d2da6db285945e3ddcec191eead
 
       - name: ci/test
-        uses: mattermost/actions/plugin-ci/test@a137067c750390bfc228375dbe745b2aa3a566e8
+        uses: mattermost/actions/plugin-ci/test@78a7031b0c913d2da6db285945e3ddcec191eead
 
   build:
     runs-on: ubuntu-latest
@@ -103,12 +103,13 @@ jobs:
           cache: true
 
       - name: ci/setup
-        uses: mattermost/actions/plugin-ci/setup@a137067c750390bfc228375dbe745b2aa3a566e8
+        uses: mattermost/actions/plugin-ci/setup@78a7031b0c913d2da6db285945e3ddcec191eead
 
       - name: ci/build
-        uses: mattermost/actions/plugin-ci/build@a137067c750390bfc228375dbe745b2aa3a566e8
+        uses: mattermost/actions/plugin-ci/build@78a7031b0c913d2da6db285945e3ddcec191eead
 
   delivery:
+    # if: ${{ github.ref_name  == 'master' }}
     runs-on: ubuntu-latest
     needs: [build]
     steps:

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -72,10 +72,10 @@ jobs:
           cache: true
 
       - name: ci/setup
-        uses: mattermost/actions/plugin-ci/setup@847dc3e0a995ab72708b8ef3e49b30bd1bbe2dfc
+        uses: mattermost/actions/plugin-ci/setup@f5602943fd346a526f5aceb7d51c6553657a4da1
 
       - name: ci/lint
-        uses: mattermost/actions/plugin-ci/lint@847dc3e0a995ab72708b8ef3e49b30bd1bbe2dfc
+        uses: mattermost/actions/plugin-ci/lint@f5602943fd346a526f5aceb7d51c6553657a4da1
 
   test:
     runs-on: ubuntu-latest
@@ -92,10 +92,10 @@ jobs:
           cache: true
 
       - name: ci/setup
-        uses: mattermost/actions/plugin-ci/setup@847dc3e0a995ab72708b8ef3e49b30bd1bbe2dfc
+        uses: mattermost/actions/plugin-ci/setup@f5602943fd346a526f5aceb7d51c6553657a4da1
 
       - name: ci/test
-        uses: mattermost/actions/plugin-ci/test@847dc3e0a995ab72708b8ef3e49b30bd1bbe2dfc
+        uses: mattermost/actions/plugin-ci/test@f5602943fd346a526f5aceb7d51c6553657a4da1
 
   build:
     runs-on: ubuntu-latest
@@ -113,10 +113,10 @@ jobs:
           cache: true
 
       - name: ci/setup
-        uses: mattermost/actions/plugin-ci/setup@847dc3e0a995ab72708b8ef3e49b30bd1bbe2dfc
+        uses: mattermost/actions/plugin-ci/setup@f5602943fd346a526f5aceb7d51c6553657a4da1
 
       - name: ci/build
-        uses: mattermost/actions/plugin-ci/build@847dc3e0a995ab72708b8ef3e49b30bd1bbe2dfc
+        uses: mattermost/actions/plugin-ci/build@f5602943fd346a526f5aceb7d51c6553657a4da1
 
   delivery:
     # if: ${{ github.ref_name  == 'master' }}

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -22,6 +22,18 @@ on:
         required: false
         type: string
 
+      artifacts:
+        description: |
+          The path or files of artifacts to upload
+        required: true
+        type: string
+
+      bucket:
+        description: |
+          The S3 bucket full path to upload
+        required: true
+        type: string
+
 permissions:
   contents: read
 
@@ -98,9 +110,14 @@ jobs:
       - name: ci/prepare-artifact
         run: mv dist/*.tar.gz dist/$GITHUB_REPOSITORY-ci.tar.gz
 
-      - name: ci/upload-artifact
-        uses: mattermost/actions/artifact-upload@a137067c750390bfc228375dbe745b2aa3a566e8
+      - name: ci/aws-configure
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
         with:
-          artifacts: dist
-          bucket: mattermost-plugins-ci/ci/
-          region: us-east-2
+          aws-region: ${{ inputs.aws-region }}
+          aws-access-key-id: ${{ secrets.PLUGIN_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.PLUGIN_AWS_SECRET_ACCESS_KEY }}
+
+      - name: ci/artifact-upload
+        shell: bash
+        run: |
+          aws s3 cp ${{ inputs.artifacts }} s3://${{ inputs.bucket }} --acl public-read --cache-control no-cache

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -119,7 +119,7 @@ jobs:
         uses: mattermost/actions/plugin-ci/build@f5602943fd346a526f5aceb7d51c6553657a4da1
 
   delivery:
-    # if: ${{ github.ref_name  == 'master' }}
+    if: ${{ github.ref_name  == 'master' || github.ref_name  == 'main' }}
     runs-on: ubuntu-latest
     needs: [build]
     steps:

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -2,7 +2,7 @@ on:
   workflow_call:
     inputs:
       artifacts:
-        default: dist
+        default: dist/*.tar.gz
         description: |
           The path or files of artifacts to upload
         required: false
@@ -42,6 +42,16 @@ on:
           The AWS region for S3 bucket
         required: false
         type: string
+
+    secrets:
+      aws-access-key-id:
+        description: |
+          The AWS access key ID
+        required: true
+      aws-secret-access-key:
+        description: |
+          The AWS access secret key
+        required: true
 
 permissions:
   contents: read
@@ -119,10 +129,6 @@ jobs:
           name: dist
           path: dist
 
-      - name: LS
-        run: ls -al
-        working-directory: dist
-
       - name: ci/prepare-artifact
         run: mv *.tar.gz ${GITHUB_REPOSITORY#*/}-ci.tar.gz
         working-directory: dist
@@ -131,8 +137,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
         with:
           aws-region: ${{ inputs.region }}
-          aws-access-key-id: ${{ secrets.PLUGIN_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.PLUGIN_AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.aws-access-key-id }}
+          aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
 
       - name: ci/artifact-upload
         shell: bash

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -1,6 +1,20 @@
 on:
   workflow_call:
     inputs:
+      artifacts:
+        default: dist
+        description: |
+          The path or files of artifacts to upload
+        required: false
+        type: string
+
+      bucket:
+        default: mattermost-plugins-ci/ci/
+        description: |
+          The S3 bucket full path to upload
+        required: false
+        type: string
+
       golang-cache-enabled:
         default: true
         description: |
@@ -22,16 +36,11 @@ on:
         required: false
         type: string
 
-      artifacts:
+      region:
+        default: us-east-2
         description: |
-          The path or files of artifacts to upload
-        required: true
-        type: string
-
-      bucket:
-        description: |
-          The S3 bucket full path to upload
-        required: true
+          The AWS region for S3 bucket
+        required: false
         type: string
 
 permissions:
@@ -80,6 +89,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    needs: [lint, test]
     steps:
       - name: Checkout repo
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
@@ -100,6 +110,7 @@ jobs:
 
   delivery:
     runs-on: ubuntu-latest
+    needs: [build]
     steps:
       - name: ci/download-artifact
         uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -56,16 +56,16 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@0143519cc3e3a31bd1a9d4b6a50d23a023b950db # v3.5.0
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version: ${{ inputs.golang-version }}
           cache: true
 
       - name: ci/setup
-        uses: mattermost/actions/plugin-ci/setup@78a7031b0c913d2da6db285945e3ddcec191eead
+        uses: mattermost/actions/plugin-ci/setup@847dc3e0a995ab72708b8ef3e49b30bd1bbe2dfc
 
       - name: ci/lint
-        uses: mattermost/actions/plugin-ci/lint@78a7031b0c913d2da6db285945e3ddcec191eead
+        uses: mattermost/actions/plugin-ci/lint@847dc3e0a995ab72708b8ef3e49b30bd1bbe2dfc
 
   test:
     runs-on: ubuntu-latest
@@ -76,16 +76,16 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@0143519cc3e3a31bd1a9d4b6a50d23a023b950db # v3.5.0
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version: ${{ inputs.golang-version }}
           cache: true
 
       - name: ci/setup
-        uses: mattermost/actions/plugin-ci/setup@78a7031b0c913d2da6db285945e3ddcec191eead
+        uses: mattermost/actions/plugin-ci/setup@847dc3e0a995ab72708b8ef3e49b30bd1bbe2dfc
 
       - name: ci/test
-        uses: mattermost/actions/plugin-ci/test@78a7031b0c913d2da6db285945e3ddcec191eead
+        uses: mattermost/actions/plugin-ci/test@847dc3e0a995ab72708b8ef3e49b30bd1bbe2dfc
 
   build:
     runs-on: ubuntu-latest
@@ -97,16 +97,16 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@0143519cc3e3a31bd1a9d4b6a50d23a023b950db # v3.5.0
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version: ${{ inputs.golang-version }}
           cache: true
 
       - name: ci/setup
-        uses: mattermost/actions/plugin-ci/setup@78a7031b0c913d2da6db285945e3ddcec191eead
+        uses: mattermost/actions/plugin-ci/setup@847dc3e0a995ab72708b8ef3e49b30bd1bbe2dfc
 
       - name: ci/build
-        uses: mattermost/actions/plugin-ci/build@0143519cc3e3a31bd1a9d4b6a50d23a023b950db
+        uses: mattermost/actions/plugin-ci/build@847dc3e0a995ab72708b8ef3e49b30bd1bbe2dfc
 
   delivery:
     # if: ${{ github.ref_name  == 'master' }}
@@ -119,13 +119,18 @@ jobs:
           name: dist
           path: dist
 
+      - name: LS
+        run: ls -al
+        working-directory: dist
+
       - name: ci/prepare-artifact
-        run: mv dist/*.tar.gz dist/$GITHUB_REPOSITORY-ci.tar.gz
+        run: mv *.tar.gz ${GITHUB_REPOSITORY#*/}-ci.tar.gz
+        working-directory: dist
 
       - name: ci/aws-configure
         uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
         with:
-          aws-region: ${{ inputs.aws-region }}
+          aws-region: ${{ inputs.region }}
           aws-access-key-id: ${{ secrets.PLUGIN_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PLUGIN_AWS_SECRET_ACCESS_KEY }}
 
@@ -133,3 +138,4 @@ jobs:
         shell: bash
         run: |
           aws s3 cp ${{ inputs.artifacts }} s3://${{ inputs.bucket }} --acl public-read --cache-control no-cache
+        working-directory: dist

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -106,7 +106,7 @@ jobs:
         uses: mattermost/actions/plugin-ci/setup@78a7031b0c913d2da6db285945e3ddcec191eead
 
       - name: ci/build
-        uses: mattermost/actions/plugin-ci/build@78a7031b0c913d2da6db285945e3ddcec191eead
+        uses: mattermost/actions/plugin-ci/build@main
 
   delivery:
     # if: ${{ github.ref_name  == 'master' }}

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -56,7 +56,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        uses: actions/setup-go@0143519cc3e3a31bd1a9d4b6a50d23a023b950db # v3.5.0
         with:
           go-version: ${{ inputs.golang-version }}
           cache: true
@@ -76,7 +76,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        uses: actions/setup-go@0143519cc3e3a31bd1a9d4b6a50d23a023b950db # v3.5.0
         with:
           go-version: ${{ inputs.golang-version }}
           cache: true
@@ -97,7 +97,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        uses: actions/setup-go@0143519cc3e3a31bd1a9d4b6a50d23a023b950db # v3.5.0
         with:
           go-version: ${{ inputs.golang-version }}
           cache: true
@@ -106,7 +106,7 @@ jobs:
         uses: mattermost/actions/plugin-ci/setup@78a7031b0c913d2da6db285945e3ddcec191eead
 
       - name: ci/build
-        uses: mattermost/actions/plugin-ci/build@22d7d0350214a27f24bebba563ea9f6a05aecd6f
+        uses: mattermost/actions/plugin-ci/build@0143519cc3e3a31bd1a9d4b6a50d23a023b950db
 
   delivery:
     # if: ${{ github.ref_name  == 'master' }}


### PR DESCRIPTION
#### Summary
Custom actions cannot read Github secrets that's why we moved this part to the reusable
workflows which they support it without an issue.

1. [[fix] Add inputs and set default values](https://github.com/mattermost/actions-workflows/commit/bf6bccf3f13e6f072d96f59805c9f1d6a2294089)
2. [[fix] point to latest changes of actions repo](https://github.com/mattermost/actions-workflows/commit/cd880acab20708bd9430feb2e0a5aebde2e7e0e6)

@spirosoik

#### Ticket Link
Ticket: https://mattermost.atlassian.net/browse/CLD-4681