### PR TITLE
Add continuous delivery for plugin

### DIFF
--- a/.github/workflows/plugin-cd.yml
+++ b/.github/workflows/plugin-cd.yml
@@ -7,7 +7,6 @@ on:
           The path or files of artifacts to upload
         required: false
         type: string
-
       bucket:
         default: mattermost-plugins-ci/release/
         description: |
@@ -64,9 +63,7 @@ jobs:
 
       - name: ci/publish-release
         run: |
-          ghr -b "$(< ./release-notes.md)" -c ${GITHUB_REF_NAME} -n ${GITHUB_REF_NAME} -delete ${GITHUB_REF_NAME} *.tar.gz
+          gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes-file release-notes.md  *.tar.gz
         working-directory: dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OWNER: ${{ github.repository_owner }}
-          REPO: ${{ github.event.repository.name }}

--- a/.github/workflows/plugin-cd.yml
+++ b/.github/workflows/plugin-cd.yml
@@ -1,0 +1,72 @@
+on:
+  workflow_call:
+    inputs:
+      artifacts:
+        default: dist/*.tar.gz
+        description: |
+          The path or files of artifacts to upload
+        required: false
+        type: string
+
+      bucket:
+        default: mattermost-plugins-ci/release/
+        description: |
+          The S3 bucket full path to upload
+        required: false
+        type: string
+
+    secrets:
+      aws-access-key-id:
+        description: |
+          The AWS access key ID
+        required: true
+      aws-secret-access-key:
+        description: |
+          The AWS access secret key
+        required: true
+      github-token:
+        description: |
+          The Github token to publish artifacts
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    if: startsWith(github.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    steps:
+      - name: ci/download-artifact
+        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+        with:
+          name: dist
+          path: dist
+
+      - name: ci/prepare-artifact
+        run: |
+          mv *.tar.gz ${GITHUB_REPOSITORY#*/}-latest.tar.gz
+          cp ${GITHUB_REPOSITORY#*/}-latest.tar.gz ${GITHUB_REPOSITORY#*/}-$GITHUB_REF_NAME.tar.gz
+        working-directory: dist
+
+      - name: ci/aws-configure
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          aws-region: ${{ inputs.region }}
+          aws-access-key-id: ${{ secrets.aws-access-key-id }}
+          aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
+
+      - name: ci/artifact-upload
+        shell: bash
+        run: |
+          aws s3 cp ${{ inputs.artifacts }} s3://${{ inputs.bucket }} --acl public-read --cache-control no-cache
+        working-directory: dist
+
+      - name: ci/publish-release
+        run: |
+          ghr -b "$(< ./release-notes.md)" -c ${GITHUB_REF_NAME} -n ${GITHUB_REF_NAME} -delete ${GITHUB_REF_NAME} *.tar.gz
+        working-directory: dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.github-token }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}

--- a/.github/workflows/plugin-cd.yml
+++ b/.github/workflows/plugin-cd.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   release:
-    if: startsWith(github.ref, 'refs/tags')
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - name: ci/download-artifact

--- a/.github/workflows/plugin-cd.yml
+++ b/.github/workflows/plugin-cd.yml
@@ -53,8 +53,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
         with:
           aws-region: ${{ inputs.region }}
-          aws-access-key-id: ${{ secrets.aws-access-key-id }}
-          aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
+          aws-access-key-id: ${{ secrets.PLUGIN_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.PLUGIN_AWS_SECRET_ACCESS_KEY }}
 
       - name: ci/artifact-upload
         shell: bash
@@ -67,6 +67,6 @@ jobs:
           ghr -b "$(< ./release-notes.md)" -c ${GITHUB_REF_NAME} -n ${GITHUB_REF_NAME} -delete ${GITHUB_REF_NAME} *.tar.gz
         working-directory: dist
         env:
-          GITHUB_TOKEN: ${{ secrets.github-token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}

--- a/.github/workflows/plugin-cd.yml
+++ b/.github/workflows/plugin-cd.yml
@@ -66,4 +66,4 @@ jobs:
           gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes-file release-notes.md  *.tar.gz
         working-directory: dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -43,16 +43,6 @@ on:
         required: false
         type: string
 
-    secrets:
-      aws-access-key-id:
-        description: |
-          The AWS access key ID
-        required: true
-      aws-secret-access-key:
-        description: |
-          The AWS access secret key
-        required: true
-
 permissions:
   contents: read
 
@@ -137,8 +127,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
         with:
           aws-region: ${{ inputs.region }}
-          aws-access-key-id: ${{ secrets.aws-access-key-id }}
-          aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
+          aws-access-key-id: ${{ secrets.PLUGIN_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.PLUGIN_AWS_SECRET_ACCESS_KEY }}
 
       - name: ci/artifact-upload
         shell: bash


### PR DESCRIPTION
#### Summary
We prepare the artifacts for release and we upload to the release bucket instead. Also we upload in parallel the artifacts as a Github Release.

#### Ticket Link
Ticket: https://mattermost.atlassian.net/browse/CLD-4681

