### PR TITLE
Change artifacts default path

### DIFF
--- a/.github/workflows/plugin-cd.yml
+++ b/.github/workflows/plugin-cd.yml
@@ -2,7 +2,7 @@ on:
   workflow_call:
     inputs:
       artifacts:
-        default: dist/*.tar.gz
+        default: "*.tar.gz"
         description: |
           The path or files of artifacts to upload
         required: false

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -2,7 +2,7 @@ on:
   workflow_call:
     inputs:
       artifacts:
-        default: dist/*.tar.gz
+        default: "*.tar.gz"
         description: |
           The path or files of artifacts to upload
         required: false


### PR DESCRIPTION
#### Summary
We are already in the working directory `dist` and we need only the `.tar.gz` files to be uploaded in the S3 bucket.
