### PR TITLE
Remove secrets as we use inherit

### DIFF
--- a/.github/workflows/plugin-cd.yml
+++ b/.github/workflows/plugin-cd.yml
@@ -14,20 +14,6 @@ on:
         required: false
         type: string
 
-    secrets:
-      aws-access-key-id:
-        description: |
-          The AWS access key ID
-        required: true
-      aws-secret-access-key:
-        description: |
-          The AWS access secret key
-        required: true
-      github-token:
-        description: |
-          The Github token to publish artifacts
-        required: true
-
 permissions:
   contents: read
 


### PR DESCRIPTION
#### Summary
In the usage of re-usable workflow we use inherit for secrets and that's why we can remove the required inputs for secrets.

