### PR TITLE
Run build job currently to test and lint

### DIFF
--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -63,7 +63,6 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [lint, test]
     steps:
       - name: Checkout repo
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
@@ -79,7 +78,7 @@ jobs:
   delivery:
     if: ${{ github.event_name != 'schedule' && (github.ref_name  == 'master' || github.ref_name  == 'main') }}
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [lint, test, build]
     steps:
       - name: ci/download-artifact
         uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1


### PR DESCRIPTION
#### Summary
QA still wants to use the build artefact from PR where `test` and `lint` fails. In large PRs where fixing tests takes time QA should still be able to use the artefacts early.

#### Ticket Link
None