### PR TITLE
Don't test and lint release builds

### DIFF
--- a/.github/workflows/plugin-cd.yml
+++ b/.github/workflows/plugin-cd.yml
@@ -26,40 +26,9 @@ permissions:
   contents: read
 
 jobs:
-  lint:
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
-        with:
-          fetch-depth: 0
-
-      - name: ci/setup
-        uses: mattermost/actions/plugin-ci/setup@0d1a5aa0352d9030d51dd6f01868351cad80ef0a
-
-      - name: ci/lint
-        uses: mattermost/actions/plugin-ci/lint@0d1a5aa0352d9030d51dd6f01868351cad80ef0a
-
-  test:
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
-        with:
-          fetch-depth: 0
-
-      - name: ci/setup
-        uses: mattermost/actions/plugin-ci/setup@0d1a5aa0352d9030d51dd6f01868351cad80ef0a
-
-      - name: ci/test
-        uses: mattermost/actions/plugin-ci/test@0d1a5aa0352d9030d51dd6f01868351cad80ef0a
-
   build:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: [lint, test]
     steps:
       - name: Checkout repo
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0


### PR DESCRIPTION
#### Summary
For the release build, running tests and linters might causes issues if they are unstable. Failing tests should not block a release. The CI in `master` and the PRs is enough to guard aginst linter and test failures.

#### Ticket Link
None