### PR TITLE
[MM-51745] Checkout repo before releasing to GitHub

### DIFF
--- a/.github/workflows/plugin-cd.yml
+++ b/.github/workflows/plugin-cd.yml
@@ -77,6 +77,10 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [release-s3]
     steps:
+      - name: cd/checkout-repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          fetch-depth: "0"
       - name: ci/download-artifact
         uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
         with:


### PR DESCRIPTION
#### Summary
Otherwise, the following happens:
```sh
Run gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes-file release-notes.md  *.tar.gz
  gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes-file release-notes.md  *.tar.gz
  shell: /usr/bin/bash -e {0}
  env:
    GITHUB_TOKEN: ***
failed to run git: fatal: not a git repository (or any of the parent directories): .git

Error: Process completed with exit code 1.
```
https://github.com/mattermost/mattermost-plugin-antivirus/actions/runs/4539534295/jobs/7999562478


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51745

