### PR TITLE
MM-51985 - Calls: Fix rudder keys are missing from prod builds

### DIFF
--- a/.github/workflows/plugin-cd.yml
+++ b/.github/workflows/plugin-cd.yml
@@ -41,6 +41,8 @@ jobs:
       - name: ci/build
         env:
           MM_RUDDER_PLUGINS_PROD: ${{ secrets.MM_RUDDER_PLUGINS_PROD }}
+          MM_RUDDER_CALLS_PROD: ${{ secrets.MM_RUDDER_CALLS_PROD }}
+          MM_RUDDER_DATAPLANE_URL: ${{ secrets.MM_RUDDER_DATAPLANE_URL }}
         uses: mattermost/actions/plugin-ci/build@0d1a5aa0352d9030d51dd6f01868351cad80ef0a
 
   release-s3:


### PR DESCRIPTION
#### Summary
- https://github.com/mattermost/mattermost-plugin-calls/pull/395 does not pass the env vars to the reusable workflows
- Add the rudder env vars needed by calls
- May as well add the dataplane url here

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-51985