### PR TITLE
Run ci/delivery step only on mattermost org plugins

### DIFF
--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -76,7 +76,7 @@ jobs:
         uses: mattermost/actions/plugin-ci/build@0d1a5aa0352d9030d51dd6f01868351cad80ef0a
 
   delivery:
-    if: ${{ github.event_name != 'schedule' && (github.ref_name  == 'master' || github.ref_name  == 'main') }}
+    if: ${{ github.repository_owner == 'mattermost' && github.event_name != 'schedule' && (github.ref_name  == 'master' || github.ref_name  == 'main') }}
     runs-on: ubuntu-latest
     needs: [lint, test, build]
     steps:


### PR DESCRIPTION
#### Summary
We need to run `ci/delivery` step only if the plugin is maintained under mattermost org.

Related issue: https://github.com/mattermost/mattermost-plugin-starter-template/issues/179
Related PR: https://github.com/mattermost/actions-workflows/pull/28

#### Ticket Link
See https://github.com/mattermost/mattermost-plugin-starter-template/issues/179#issuecomment-1562904632
