### PR TITLE
Pass through `golangci-lint-version` input

### DIFF
--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -43,6 +43,8 @@ jobs:
 
       - name: ci/setup
         uses: mattermost/actions/plugin-ci/setup@0d1a5aa0352d9030d51dd6f01868351cad80ef0a
+        with:
+          golangci-lint-version: ${{ inputs.golangci-lint-version }}
 
       - name: ci/lint
         uses: mattermost/actions/plugin-ci/lint@0d1a5aa0352d9030d51dd6f01868351cad80ef0a


### PR DESCRIPTION
#### Summary

I am trying to set a `golangci-lint-version` version different from the default which is a bit out of date. The problem seems to be that we are not passing it through to the [setup action](https://github.com/mattermost/actions/blob/93502485eec8db2fd67b54c71a02462e06d0fa46/plugin-ci/setup/action.yaml#L12) and I am not sure if there's another way to override it from the higher level which uses this workflow.

