### PR TITLE
Update golangci-lint to v1.52.2

### DIFF
--- a/.github/workflows/plugin-cd.yml
+++ b/.github/workflows/plugin-cd.yml
@@ -36,14 +36,14 @@ jobs:
           fetch-depth: 0
 
       - name: ci/setup
-        uses: mattermost/actions/plugin-ci/setup@4945d55b15d3bef108a7f7d6bd53ae4532616d17
+        uses: mattermost/actions/plugin-ci/setup@8c02b13d20a7121b0dbec4157c9f70593bad4e8c
 
       - name: ci/build
         env:
           MM_RUDDER_PLUGINS_PROD: ${{ secrets.MM_RUDDER_PLUGINS_PROD }}
           MM_RUDDER_CALLS_PROD: ${{ secrets.MM_RUDDER_CALLS_PROD }}
           MM_RUDDER_DATAPLANE_URL: ${{ secrets.MM_RUDDER_DATAPLANE_URL }}
-        uses: mattermost/actions/plugin-ci/build@4945d55b15d3bef108a7f7d6bd53ae4532616d17
+        uses: mattermost/actions/plugin-ci/build@8c02b13d20a7121b0dbec4157c9f70593bad4e8c
 
   release-s3:
     if: startsWith(github.ref, 'refs/tags/v') && github.repository_owner == 'mattermost'

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -42,12 +42,12 @@ jobs:
           fetch-depth: 0
 
       - name: ci/setup
-        uses: mattermost/actions/plugin-ci/setup@4945d55b15d3bef108a7f7d6bd53ae4532616d17
+        uses: mattermost/actions/plugin-ci/setup@8c02b13d20a7121b0dbec4157c9f70593bad4e8c
         with:
           golangci-lint-version: ${{ inputs.golangci-lint-version }}
 
       - name: ci/lint
-        uses: mattermost/actions/plugin-ci/lint@4945d55b15d3bef108a7f7d6bd53ae4532616d17
+        uses: mattermost/actions/plugin-ci/lint@8c02b13d20a7121b0dbec4157c9f70593bad4e8c
 
   test:
     runs-on: ubuntu-latest
@@ -58,10 +58,10 @@ jobs:
           fetch-depth: 0
 
       - name: ci/setup
-        uses: mattermost/actions/plugin-ci/setup@4945d55b15d3bef108a7f7d6bd53ae4532616d17
+        uses: mattermost/actions/plugin-ci/setup@8c02b13d20a7121b0dbec4157c9f70593bad4e8c
 
       - name: ci/test
-        uses: mattermost/actions/plugin-ci/test@4945d55b15d3bef108a7f7d6bd53ae4532616d17
+        uses: mattermost/actions/plugin-ci/test@8c02b13d20a7121b0dbec4157c9f70593bad4e8c
 
   build:
     runs-on: ubuntu-latest
@@ -72,10 +72,10 @@ jobs:
           fetch-depth: 0
 
       - name: ci/setup
-        uses: mattermost/actions/plugin-ci/setup@4945d55b15d3bef108a7f7d6bd53ae4532616d17
+        uses: mattermost/actions/plugin-ci/setup@8c02b13d20a7121b0dbec4157c9f70593bad4e8c
 
       - name: ci/build
-        uses: mattermost/actions/plugin-ci/build@4945d55b15d3bef108a7f7d6bd53ae4532616d17
+        uses: mattermost/actions/plugin-ci/build@8c02b13d20a7121b0dbec4157c9f70593bad4e8c
 
   delivery:
     if: ${{ github.repository_owner == 'mattermost' && github.event_name != 'schedule' && (github.ref_name  == 'master' || github.ref_name  == 'main') }}


### PR DESCRIPTION
#### Summary
Downstream https://github.com/mattermost/actions/pull/14

#### Ticket Link
None
