### PR TITLE
Update golangci-lint to v1.52.2 (2nd try)

### DIFF
--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -16,7 +16,7 @@ on:
         type: string
 
       golangci-lint-version:
-        default: "v1.49.0"
+        default: "v1.52.2"
         description: |
           Set the version for golangci-lint
         required: false


### PR DESCRIPTION
#### Summary
Since #30 was merged, the default value from https://github.com/mattermost/actions-workflows/blob/e6f70b86c59ff26be043e5262e4cb7dc20a4b4d4/.github/workflows/plugin-ci.yml#L18-L19 overwrites the one in `actions`. Hence, https://github.com/mattermost/actions-workflows/pull/33 had no effect.

#### Ticket Link
None