### PR TITLE
Add ability to specify go version used in ci/setup workflows

### DIFF
--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -22,6 +22,13 @@ on:
         required: false
         type: string
 
+      golang-version:
+        default: "1.21"
+        description: |
+          Set the version for golang
+        required: false
+        type: string
+
       region:
         default: us-east-2
         description: |
@@ -45,6 +52,7 @@ jobs:
         uses: mattermost/actions/plugin-ci/setup@8c02b13d20a7121b0dbec4157c9f70593bad4e8c
         with:
           golangci-lint-version: ${{ inputs.golangci-lint-version }}
+          golang-version: ${{ inputs.golang-version }}
 
       - name: ci/lint
         uses: mattermost/actions/plugin-ci/lint@8c02b13d20a7121b0dbec4157c9f70593bad4e8c
@@ -59,6 +67,8 @@ jobs:
 
       - name: ci/setup
         uses: mattermost/actions/plugin-ci/setup@8c02b13d20a7121b0dbec4157c9f70593bad4e8c
+        with:
+          golang-version: ${{ inputs.golang-version }}
 
       - name: ci/test
         uses: mattermost/actions/plugin-ci/test@8c02b13d20a7121b0dbec4157c9f70593bad4e8c
@@ -73,6 +83,8 @@ jobs:
 
       - name: ci/setup
         uses: mattermost/actions/plugin-ci/setup@8c02b13d20a7121b0dbec4157c9f70593bad4e8c
+        with:
+          golang-version: ${{ inputs.golang-version }}
 
       - name: ci/build
         uses: mattermost/actions/plugin-ci/build@8c02b13d20a7121b0dbec4157c9f70593bad4e8c


### PR DESCRIPTION
#### Summary
- Calls needs to be able to specify the Go version used in the build process

#### Ticket Link
- none
