### PR TITLE
deps: golangci-lint to 1.55.2

### DIFF
--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -16,7 +16,7 @@ on:
         type: string
 
       golangci-lint-version:
-        default: "v1.52.2"
+        default: "v1.55.2"
         description: |
           Set the version for golangci-lint
         required: false


### PR DESCRIPTION
#### Summary

This pull requests upgrades `golangci-lint` to the latest version to prevent issues in plugin workflows.

