### PR TITLE
upgrade download-artifact to 4.1.7

### DIFF
--- a/.github/workflows/plugin-cd.yml
+++ b/.github/workflows/plugin-cd.yml
@@ -60,7 +60,7 @@ jobs:
     needs: [build]
     steps:
       - name: ci/download-artifact
-        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: dist
           path: dist
@@ -95,7 +95,7 @@ jobs:
         with:
           fetch-depth: "0"
       - name: ci/download-artifact
-        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: dist
           path: dist

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -105,7 +105,7 @@ jobs:
     needs: [lint, test, build]
     steps:
       - name: ci/download-artifact
-        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: dist
           path: dist


### PR DESCRIPTION
#### Summary
This complements the changes in https://github.com/mattermost/actions/pull/22 to `ci/upload-artifact` and fixes the broken pipeline.

#### Ticket Link
None