### PR TITLE
Remove repo_name from inputs in favor of using github context. Fix typo.

### DIFF
--- a/.github/workflows/snyk-sbom.yml
+++ b/.github/workflows/snyk-sbom.yml
@@ -6,10 +6,6 @@ on:
         default: true
         required: false
         type: boolean
-      repo_name:
-        description: 'Name of repo to be used in sbom name ex. sbom-REPONAME-vX.Y.Z.json'
-        required: true
-        type: string
 
 permissions:
   contents: write
@@ -31,7 +27,7 @@ jobs:
 
       - name: sbom/generate-monorepo
         if: ${{ inputs.is_monorepo }}
-        run: snyk sbom --format=cyclonedx1.5+json --all-projects > sbom-${{ inputs.repo_name}}}-${{ github.event.release.tag_name }}.json
+        run: snyk sbom --format=cyclonedx1.5+json --all-projects > sbom-${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.json
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
@@ -44,4 +40,4 @@ jobs:
       - name: sbom/upload
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ github.event.release.tag_name }}" sbom-${{ inputs.repo_name}}}-${{ github.event.release.tag_name }}.json
+        run: gh release upload "${{ github.event.release.tag_name }}" sbom-${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.json


### PR DESCRIPTION
#### Summary

- Remove `repo_name` in favor of using the github context
- Remove extra curly brace

#### Ticket Link

NA
