### PR TITLE
feat: support mage in ci/cd pipelines

### DIFF
--- a/.github/workflows/plugin-cd.yml
+++ b/.github/workflows/plugin-cd.yml
@@ -47,6 +47,9 @@ jobs:
         with:
           golang-version: ${{ inputs.golang-version }}
 
+      - name: Install mage
+        run: go install github.com/magefile/mage@latest
+
       - name: ci/build
         env:
           MM_RUDDER_PLUGINS_PROD: ${{ secrets.MM_RUDDER_PLUGINS_PROD }}

--- a/.github/workflows/plugin-cd.yml
+++ b/.github/workflows/plugin-cd.yml
@@ -22,6 +22,13 @@ on:
         required: false
         type: string
 
+      mage-version:
+        default: "v1.15.0"
+        description: |
+          Set the version for mage
+        required: false
+        type: string
+
       region:
         default: us-east-1
         description: |
@@ -48,7 +55,7 @@ jobs:
           golang-version: ${{ inputs.golang-version }}
 
       - name: Install mage
-        run: go install github.com/magefile/mage@latest
+        run: go install github.com/magefile/mage@${{ inputs.mage-version }}
 
       - name: ci/build
         env:

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -29,6 +29,13 @@ on:
         required: false
         type: string
 
+      mage-version:
+        default: "v1.15.0"
+        description: |
+          Set the version for mage
+        required: false
+        type: string
+
       region:
         default: us-east-1
         description: |
@@ -63,7 +70,7 @@ jobs:
           golang-version: ${{ inputs.golang-version }}
 
       - name: Install mage
-        run: go install github.com/magefile/mage@latest
+        run: go install github.com/magefile/mage@${{ inputs.mage-version }}
 
       - name: ci/lint
         uses: mattermost/actions/plugin-ci/lint@d5174b860704729f4c14ef8489ae075742bfa08a # v1.0.0
@@ -83,7 +90,7 @@ jobs:
           golang-version: ${{ inputs.golang-version }}
 
       - name: Install mage
-        run: go install github.com/magefile/mage@latest
+        run: go install github.com/magefile/mage@${{ inputs.mage-version }}
 
       - name: ci/test
         uses: mattermost/actions/plugin-ci/test@d5174b860704729f4c14ef8489ae075742bfa08a # v1.0.0
@@ -103,7 +110,7 @@ jobs:
           golang-version: ${{ inputs.golang-version }}
 
       - name: Install mage
-        run: go install github.com/magefile/mage@latest
+        run: go install github.com/magefile/mage@${{ inputs.mage-version }}
 
       - name: ci/build
         uses: mattermost/actions/plugin-ci/build@d5174b860704729f4c14ef8489ae075742bfa08a # v1.0.0

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -62,6 +62,9 @@ jobs:
           golangci-lint-version: ${{ inputs.golangci-lint-version }}
           golang-version: ${{ inputs.golang-version }}
 
+      - name: Install mage
+        run: go install github.com/magefile/mage@latest
+
       - name: ci/lint
         uses: mattermost/actions/plugin-ci/lint@d5174b860704729f4c14ef8489ae075742bfa08a # v1.0.0
 
@@ -79,6 +82,9 @@ jobs:
         with:
           golang-version: ${{ inputs.golang-version }}
 
+      - name: Install mage
+        run: go install github.com/magefile/mage@latest
+
       - name: ci/test
         uses: mattermost/actions/plugin-ci/test@d5174b860704729f4c14ef8489ae075742bfa08a # v1.0.0
 
@@ -95,6 +101,9 @@ jobs:
         uses: mattermost/actions/plugin-ci/setup@d5174b860704729f4c14ef8489ae075742bfa08a # v1.0.0
         with:
           golang-version: ${{ inputs.golang-version }}
+
+      - name: Install mage
+        run: go install github.com/magefile/mage@latest
 
       - name: ci/build
         uses: mattermost/actions/plugin-ci/build@d5174b860704729f4c14ef8489ae075742bfa08a # v1.0.0


### PR DESCRIPTION
#### Summary

This change installs mage in the plugin pipelines adding an input to allow consumers to specify a version.

This was done on an effort to migrate our current `make` workflows to `mage`: https://github.com/mattermost/mattermost-plugin-legal-hold/pull/136