### PR TITLE
Add Dependabot configuration for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    reviewers:
+      - "mattermost/cloud-sre"
+    open-pull-requests-limit: 5
+    groups:
+      Github Actions updates:
+        applies-to: version-updates
+        dependency-type: production
+    schedule:
+      # Check for updates to GitHub Actions every week
+      day: "monday"
+      time: "09:00"
+      interval: "weekly"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-*   @mattermost/core-build-engineers


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This new configuration sets up Dependabot to check for updates to GitHub Actions weekly, with a limit of 5 open pull requests and specific reviewers assigned. It also groups version updates for production dependencies.

Related : https://github.com/mattermost/mattermost-plugin-confluence/pull/143 
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
