### PR TITLE
Fix SBOM name for non-monorepos. Bump Snyk CLI version

### DIFF
--- a/.github/workflows/snyk-sbom.yml
+++ b/.github/workflows/snyk-sbom.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: '22.6.0'
 
       - name: sbom/install-snyk
-        run: npm install -g snyk@1.1293.0
+        run: npm install -g snyk@1.1296.1
 
       - name: sbom/generate-monorepo
         if: ${{ inputs.is_monorepo }}
@@ -33,7 +33,7 @@ jobs:
 
       - name: sbom/generate-nonmonorepo
         if: ${{ ! inputs.is_monorepo }}
-        run: snyk sbom --format=cyclonedx1.5+json > sbom.json
+        run: snyk sbom --format=cyclonedx1.5+json > sbom-${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.json
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 


### PR DESCRIPTION
#### Summary

TLDR:
- bump Snyk CLI version
- fix SBOM name for non-monorepos to match expected name when uploading

Detailed summary:
The workflow generates SBOMs for either monorepos or non-monorepos. The name of the SBOM, regardless of which is being generated, should be the same. This fixes the fact that the non-monorepo file name was incorrect.

#### Ticket Link

NA
