### PR TITLE
Update pipelines for AWS creds to assume a role 

### DIFF
--- a/.github/workflows/plugin-cd.yml
+++ b/.github/workflows/plugin-cd.yml
@@ -72,11 +72,11 @@ jobs:
         working-directory: dist
 
       - name: ci/aws-configure
-        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df #v4.2.1
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
-          aws-region: ${{ inputs.region }}
-          aws-access-key-id: ${{ secrets.PLUGIN_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.PLUGIN_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/mattermost-release-plugin-store-role
+          role-chaining: true # Enable chaining from existing credentials
 
       - name: ci/artifact-upload
         shell: bash

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -115,11 +115,11 @@ jobs:
         working-directory: dist
 
       - name: ci/aws-configure
-        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df #v4.2.1
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
-          aws-region: ${{ inputs.region }}
-          aws-access-key-id: ${{ secrets.PLUGIN_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.PLUGIN_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/mattermost-release-plugin-store-role
+          role-chaining: true # Enable chaining from existing credentials
 
       - name: ci/artifact-upload
         shell: bash


### PR DESCRIPTION
#### Summary
Update pipelines for AWS creds to assume a role 

Modified the AWS configuration in both plugin-cd.yml and plugin-ci.yml to use a specific region (us-east-1) and assume a role for credentials, enabling role chaining. This change enhances security and aligns with best practices for AWS credential management.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-9264
