### PR TITLE
Add dependency confusion checker using super-confused

### DIFF
--- a/.github/workflows/dependency-confusion.yml
+++ b/.github/workflows/dependency-confusion.yml
@@ -1,0 +1,35 @@
+name: Dependency Confusion Check
+
+on: pull_request
+
+env:
+  NODE_VERSION: '22.19.0'
+  SUPER_CONFUSED_VERSION: '1.2.0'
+
+jobs:
+  super-confused:
+    name: Run super-confused
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install super-confused
+        run: npm install -g super-confused@${{ env.SUPER_CONFUSED_VERSION }}
+
+      - name: Scan repository with super-confused
+        shell: bash
+        run: |
+          set -o pipefail
+          super-confused --json . > super-confused-report.json || true
+          if [ -s super-confused-report.json ]; then
+            echo "super-confused detected potential dependency confusion:"
+            cat super-confused-report.json
+            exit 1
+          fi

--- a/.github/workflows/dependency-confusion.yml
+++ b/.github/workflows/dependency-confusion.yml
@@ -27,7 +27,10 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          super-confused --json . > super-confused-report.json || true
+          if ! super-confused --json . > super-confused-report.json; then
+            echo "super-confused execution failed"
+            exit 2
+          fi
           if [ -s super-confused-report.json ]; then
             echo "super-confused detected potential dependency confusion:"
             cat super-confused-report.json


### PR DESCRIPTION
#### Summary

A reusable workflow that utilizes [super-confused](https://github.com/6mile/super-confused) to analyze `package.json`, `go.mod`, etc for potential dependency confusion attacks.

See working examples here:
- https://github.com/enzowritescode/workflow-tests/pull/2
- https://github.com/enzowritescode/workflow-tests/pull/1

#### Ticket Link

NA
